### PR TITLE
feat: wrap around filter

### DIFF
--- a/include/srf_laser_odometry/nodes/srf_node.h
+++ b/include/srf_laser_odometry/nodes/srf_node.h
@@ -47,7 +47,7 @@ class CLaserOdometry2D : public rclcpp::Node
     std::string odom_topic, odom_frame_id_;
     std::string init_pose_from_topic;
     std::string operation_mode_;
-    double laser_min_range_, laser_max_range_, increment_covariance_threshold_;
+    double laser_min_range_, laser_max_range_, increment_covariance_threshold_, laser_wrap_around_filter_rad_;
     bool publish_tf_;
     Pose3d robot_pose, robot_oldpose;
     int laser_counter, laser_decimation_;

--- a/src/nodes/srf_node.cpp
+++ b/src/nodes/srf_node.cpp
@@ -65,6 +65,7 @@ CLaserOdometry2D::CLaserOdometry2D() : Node("SRF_laser_odom")
     this->declare_parameter<double>("laser_min_range", -1.0);
     this->declare_parameter<double>("laser_max_range", -1.0);
     this->declare_parameter<double>("increment_covariance_threshold", std::numeric_limits<double>::max());
+    this->declare_parameter<double>("laser_wrap_around_filter_rad", 0.0);
     this->declare_parameter<std::string>("operation_mode",
                                          "HYBRID"); // CS=consecutiveScans, KS=keyScans, HYBRID=threeScansWithKeyScan
 
@@ -78,6 +79,7 @@ CLaserOdometry2D::CLaserOdometry2D() : Node("SRF_laser_odom")
     laser_min_range_ = this->get_parameter("laser_min_range").get_value<double>();
     laser_max_range_ = this->get_parameter("laser_max_range").get_value<double>();
     increment_covariance_threshold_ = this->get_parameter("increment_covariance_threshold").get_value<double>();
+    laser_wrap_around_filter_rad_ = this->get_parameter("laser_wrap_around_filter_rad").get_value<double>();
     operation_mode_ = this->get_parameter("operation_mode").get_value<std::string>();
 
     tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock());
@@ -369,8 +371,16 @@ void CLaserOdometry2D::laser_callback(sensor_msgs::msg::LaserScan::ConstSharedPt
                 // copy laser scan to internal srf variable
                 for (unsigned int i = 0; i < last_scan.ranges.size(); i++)
                 {
+                    float angle = last_scan.angle_min + i * last_scan.angle_increment;
                     // Check min-max distances, e.g. to avoid including points of the own robot
                     if ((last_scan.ranges[i] > laser_max_range_) || (last_scan.ranges[i] < laser_min_range_))
+                    {
+                        srf_obj_.range_wf(i) = 0.f; // invalid measurement
+                        last_scan.ranges[i] = 0.0;
+                    }
+                    // Filter laser points near the wrap around region (near -pi and pi)
+                    else if (angle >= (M_PI - laser_wrap_around_filter_rad_) ||
+                             angle <= (-M_PI + laser_wrap_around_filter_rad_))
                     {
                         srf_obj_.range_wf(i) = 0.f; // invalid measurement
                         last_scan.ranges[i] = 0.0;


### PR DESCRIPTION
With 360deg laser, the wrap around (between pi and -pi) causes the estimation to explode, which triggers the resetting mechanism continuously.

A built-in angular filter is added to handle the scans near the wrap around angle, fixing this issue while allowing the rest of the nodes depending on the scans to have the full 360deg.