### PR TITLE
fix: hallway patch

### DIFF
--- a/include/srf_laser_odometry/nodes/srf_node.h
+++ b/include/srf_laser_odometry/nodes/srf_node.h
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 
 #include "geometry_msgs/msg/pose.hpp"
+#include "geometry_msgs/msg/twist_with_covariance_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
@@ -47,7 +48,8 @@ class CLaserOdometry2D : public rclcpp::Node
     std::string odom_topic, odom_frame_id_;
     std::string init_pose_from_topic;
     std::string operation_mode_;
-    double laser_min_range_, laser_max_range_, increment_covariance_threshold_, laser_wrap_around_filter_rad_;
+    double laser_min_range_, laser_max_range_, increment_covariance_threshold_, laser_wrap_around_filter_rad_,
+        ref_odom_min_threshold_, ref_odom_rel_diff_threshold_, ref_odom_timeout_s_;
     bool publish_tf_;
     Pose3d robot_pose, robot_oldpose;
     int laser_counter, laser_decimation_;
@@ -74,14 +76,17 @@ class CLaserOdometry2D : public rclcpp::Node
     std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_{nullptr};
     rclcpp::Time last_odom_time;
     nav_msgs::msg::Odometry initial_robot_pose;
+    geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr last_ref_odom_msg_;
 
     // Subscriptions & Publishers
     rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr laser_sub;
     rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr initPose_sub;
     rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub;
     rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr laser_pub;
+    rclcpp::Subscription<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr ref_odom_sub_;
 
     // CallBacks
     void laser_callback(sensor_msgs::msg::LaserScan::ConstSharedPtr new_scan);
     void init_pose_callback(nav_msgs::msg::Odometry::ConstSharedPtr new_initPose);
+    void ref_odom_callback(geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg);
 };

--- a/src/nodes/srf_node.cpp
+++ b/src/nodes/srf_node.cpp
@@ -60,6 +60,10 @@ CLaserOdometry2D::CLaserOdometry2D() : Node("SRF_laser_odom")
     this->declare_parameter<std::string>("base_frame_id", "/base_link");
     this->declare_parameter<std::string>("odom_topic", "/odom");
     this->declare_parameter<std::string>("odom_frame_id", "/odom");
+    this->declare_parameter<std::string>("ref_odom_topic", "/encoder_odom");
+    this->declare_parameter<double>("ref_odom_min_threshold", 0.1);
+    this->declare_parameter<double>("ref_odom_rel_diff_threshold", 0.8);
+    this->declare_parameter<double>("ref_odom_timeout_s", 0.1);
     this->declare_parameter<std::string>("init_pose_from_topic", "");
     this->declare_parameter<int>("laser_decimation", 1);
     this->declare_parameter<double>("laser_min_range", -1.0);
@@ -74,6 +78,10 @@ CLaserOdometry2D::CLaserOdometry2D() : Node("SRF_laser_odom")
     base_frame_id_ = this->get_parameter("base_frame_id").get_value<std::string>();
     auto odom_topic = this->get_parameter("odom_topic").get_value<std::string>();
     odom_frame_id_ = this->get_parameter("odom_frame_id").get_value<std::string>();
+    auto ref_odom_topic = this->get_parameter("ref_odom_topic").get_value<std::string>();
+    ref_odom_min_threshold_ = this->get_parameter("ref_odom_min_threshold").get_value<double>();
+    ref_odom_rel_diff_threshold_ = this->get_parameter("ref_odom_rel_diff_threshold").get_value<double>();
+    ref_odom_timeout_s_ = this->get_parameter("ref_odom_timeout_s").get_value<double>();
     auto init_pose_from_topic = this->get_parameter("init_pose_from_topic").get_value<std::string>();
     laser_decimation_ = this->get_parameter("laser_decimation").get_value<int>();
     laser_min_range_ = this->get_parameter("laser_min_range").get_value<double>();
@@ -92,6 +100,8 @@ CLaserOdometry2D::CLaserOdometry2D() : Node("SRF_laser_odom")
         laser_scan_topic, 1, std::bind(&CLaserOdometry2D::laser_callback, this, std::placeholders::_1));
     odom_pub = this->create_publisher<nav_msgs::msg::Odometry>(odom_topic, 5);
     laser_pub = this->create_publisher<sensor_msgs::msg::LaserScan>("srf_laser_truncated", 5);
+    ref_odom_sub_ = this->create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(
+        ref_odom_topic, 10, std::bind(&CLaserOdometry2D::ref_odom_callback, this, std::placeholders::_1));
 
     // init pose
     //----------
@@ -281,6 +291,26 @@ void CLaserOdometry2D::publish_pose_from_SRF()
         double ang_speed = srf_obj_.kai_loc(2) / time_inc_sec;
         robot_oldpose = robot_pose;
 
+        // Ensure SRF velocitity is coherent with reference odometry
+        // If deviation is larger than threshold, reset SRF
+        if (last_ref_odom_msg_ &&
+            (rclcpp::Time(last_odom_time) - last_ref_odom_msg_->header.stamp).seconds() < ref_odom_timeout_s_)
+        {
+            double ref_odom_vel =
+                std::hypot(last_ref_odom_msg_->twist.twist.linear.x, last_ref_odom_msg_->twist.twist.linear.y);
+            double srf_vel = std::hypot(lin_speed_x, lin_speed_y);
+            if (srf_vel / ref_odom_vel < ref_odom_rel_diff_threshold_ && ref_odom_vel > ref_odom_min_threshold_)
+            {
+                RCLCPP_WARN(
+                    this->get_logger(),
+                    "SRF velocity (%.3f m/s) is lower than %.0f%% of reference odom velocity (%.3f m/s). Assuming "
+                    "hallway condition. Resetting.",
+                    srf_vel, ref_odom_rel_diff_threshold_ * 100.0, ref_odom_vel);
+                reset();
+                return;
+            }
+        }
+
         // first, we'll publish the odometry over tf
         //---------------------------------------
         if (publish_tf_)
@@ -407,6 +437,11 @@ void CLaserOdometry2D::laser_callback(sensor_msgs::msg::LaserScan::ConstSharedPt
             }
         }
     }
+}
+
+void CLaserOdometry2D::ref_odom_callback(geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg)
+{
+    last_ref_odom_msg_ = msg;
 }
 
 void CLaserOdometry2D::init_pose_callback(nav_msgs::msg::Odometry::ConstSharedPtr new_initPose)


### PR DESCRIPTION
L'odométrie laser de SRF n'est pas en mesure d'estimer correctement le déplacement dans les corridors pour les raisons suivantes :

1) Les éléments dynamiques sont ignorés par SRF. Dans un corridor avec des gens à l'avant et à l'arrière du robot ou du bruit de lectures du LiDAR sur les murs distants, les seuls éléments considérés sont les murs de côté du corridor.

2) Pour des murs de côtés sans relief important, l'estimation de déplacement de SRF dans le sens parallèle aux murs est erroné, car entre deux lectures du lidar seul le déplacement perpendiculaire aux murs est notables.
 
Pour résoudre ce problème, une odométrie de référence est introduite. En l'occurrence, l'odométrie des encodeurs. En cas de désagrément significatif (20%) entre l'odométrie de référence et l'odométrie de SRF, l'estimateur est réinitialisé car nous assumons un corridor.